### PR TITLE
複数Proxy Server 対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ npm install --global
 connect-to-http-proxy <プロキシサーバーHostname>:<プロキシサーバーPort> <接続先Hostname> <接続先Port>
 ```
 
+#### 接続先プロキシサーバーの複数指定
+`<プロキシサーバーHostname>:<プロキシサーバーPort>` は `,` (カンマ) 区切りで複数指定することが可能
+
+```
+connect-to-http-proxy proxy.intra.example.co.jp:8080,proxy.intra.example.co.jp:8081 example.com 80
+```
+
+`proxy.pac` のように、先頭から接続を試みて、 `500 ms` 以内に `CONNECT` に成功しない場合は次のプロキシサーバーへの接続を試みる
+
 ## 使用例
 プロキシサーバー `proxy.intra.example.co.jp:8080` を経由して `example.com:80` にHTTPリクエストを送る例
 

--- a/connect.js
+++ b/connect.js
@@ -11,14 +11,13 @@ const assert = require('assert');
  */
 function connect(proxyServerHost, destHostname, destPort, inputStream, outputStream) {
     assert(proxyServerHost, 'http-proxy-server arg ("hostname:port") required.');
+    assert(destHostname, 'destination-server hostname arg required.');
+    assert(destPort, 'destination-server port arg required.');
 
     const {
         hostname: proxyHostname,
         port: proxyPort,
     } = new URL(`http://${proxyServerHost}`);
-
-    assert(destHostname, 'destination-server hostname arg required.');
-    assert(destPort, 'destination-server port arg required.');
 
     const proxyRequestOptions = {
         hostname: proxyHostname,

--- a/index.js
+++ b/index.js
@@ -2,8 +2,8 @@
 
 const connect = require('./connect');
 
-const proxyServerHost = process.argv[2];
+const proxyServerHosts = process.argv[2];
 const destHostname = process.argv[3];
 const destPort = process.argv[4];
 
-connect(proxyServerHost, destHostname, destPort, process.stdin, process.stdout);
+connect(proxyServerHosts, destHostname, destPort, process.stdin, process.stdout);


### PR DESCRIPTION
proxy.pac のように、1番目へのconnectに失敗したら2番目へconnectを試みる

## 参考
[プロキシ自動設定ファイル - HTTP | MDN](https://developer.mozilla.org/ja/docs/Web/HTTP/Proxy_servers_and_tunneling/Proxy_Auto-Configuration_PAC_file)

```
PROXY w3proxy.netscape.com:8080; PROXY mozilla.netscape.com:8081
```

※ 区切り文字は `;` から `,` に変更した

## TODO
- [x] 実装
- [x] test
  - `FIXME: server2.connectRequestUrlPromise が resolve も reject もされていないことを確認する`
- [x] README 更新
- [x] merge 待ち: https://github.com/tksugimoto/node.js-connect-to-http-proxy/pull/1